### PR TITLE
Include workspace id of admin

### DIFF
--- a/lib/passport-intercom/strategy.js
+++ b/lib/passport-intercom/strategy.js
@@ -94,6 +94,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
 
     var profile = { provider: 'intercom' };
     profile.id = json.id;
+    (json.app && json.app.id_code)?profile.workspace_id = json.app.id_code: '';
     profile.displayName = json.name;
     profile.emails = [{ value: json.email, type: "default" }];
     profile.photos = [json.avatar.image_url];


### PR DESCRIPTION
The admin who is authorizing messenger app should include workspace ID in which installing APP.